### PR TITLE
Change wording about the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ using `LockKit.shared` singleton.
 
 ### Initialization
 
-In order to interact with bike locks, you must intialize the SDK with the API
+In order to interact with bike locks, you must intialize the SDK with the SDK authorization
 token provided to you by Donkey Republic:
 
     LockKit.shared.initializeSDK(apiToken: "MyDonkeyToken", errorHandler: { (error) in


### PR DESCRIPTION
When it says API token then an aggregator may think that it's the TOMP API token.
So maybe naming it SDK authorization token would make it a little bit more clear that it's not the same.